### PR TITLE
bump guice to 4.2.2, jdk11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <java.release>1.8</java.release>
-    <guice.version>4.2.1</guice.version>
+    <guice.version>4.2.2</guice.version>
     <gwt.version>2.8.2</gwt.version>
 
     <jsr330.version>1</jsr330.version> <!-- @Inject, @Singleton -->


### PR DESCRIPTION
Hi!

  guice 4.2.2 was released and it (at least) contains fixes for reflection based access, would be great if that dep could be bumped.

Thank you,
T.